### PR TITLE
c-ares-sys: Use metadeps to depend on libcares declaratively

### DIFF
--- a/c-ares-sys/Cargo.toml
+++ b/c-ares-sys/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["DNS", "c-ares"]
 
 [build-dependencies]
 gcc = "0.3"
-pkg-config = "0.3"
+metadeps = "1"
 
 [dependencies]
 libc = "0.2"
@@ -21,3 +21,6 @@ c-types = "1.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2"
+
+[package.metadata.pkg-config]
+libcares = "1.12.0"

--- a/c-ares-sys/build.rs
+++ b/c-ares-sys/build.rs
@@ -1,5 +1,5 @@
 extern crate gcc;
-extern crate pkg_config;
+extern crate metadeps;
 
 use std::env;
 use std::fs;
@@ -15,10 +15,7 @@ macro_rules! t {
 
 fn main() {
     // Use the installed libcares if it is available.
-    if pkg_config::Config::new()
-        .atleast_version("1.12.0")
-            .find("libcares")
-            .is_ok() {
+    if metadeps::probe().is_ok() {
         return
     }
 


### PR DESCRIPTION
This makes it easier for distribution packaging tools to generate
appropriate package dependencies on libcares.