### PR TITLE
c-ares-sys: use pkg-config directly

### DIFF
--- a/c-ares-sys/Cargo.toml
+++ b/c-ares-sys/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 [build-dependencies]
 cc = "1"
 fs_extra = "1.1"
-pkg-config = "0.3"
+pkg-config = "0.3.19"
 
 [dependencies]
 libc = "0.2"

--- a/c-ares-sys/Cargo.toml
+++ b/c-ares-sys/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 [build-dependencies]
 cc = "1"
 fs_extra = "1.1"
-metadeps = "1.1.1"
+pkg-config = "0.3"
 
 [dependencies]
 libc = "0.2"
@@ -27,5 +27,3 @@ winapi = { version = "0.3", features = ["winsock2"] }
 [target.'cfg(target_os = "android")'.dependencies]
 jni-sys = "0.3"
 
-[package.metadata.pkg-config]
-libcares = "1.15.0"

--- a/c-ares-sys/build.rs
+++ b/c-ares-sys/build.rs
@@ -1,6 +1,5 @@
 extern crate cc;
 extern crate fs_extra;
-extern crate metadeps;
 
 use std::env;
 use std::ffi::OsString;
@@ -23,7 +22,7 @@ fn main() {
     println!("cargo:rerun-if-changed=c-ares");
 
     // Use the installed libcares if it is available.
-    if metadeps::probe().is_ok() {
+    if pkg_config::Config::new().atleast_version("1.15.0").probe("libcares").is_ok() {
         return;
     }
 


### PR DESCRIPTION
metadeps has some outdated dependencies, is there any reason to not use pkg-config directly?