### PR TITLE
Require c-ares 1.18

### DIFF
--- a/c-ares-sys/Cargo.toml
+++ b/c-ares-sys/Cargo.toml
@@ -29,4 +29,4 @@ winapi = { version = "0.3", features = ["winsock2"] }
 jni-sys = "0.3"
 
 [package.metadata.pkg-config]
-libcares = "1.17.1"
+libcares = "1.18.0"


### PR DESCRIPTION
Should have published before adding the URI record support: currently
we're probably broken for folk who do have a recent c-ares on their
system.