### PR TITLE
add once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ bitflags = "2.0"
 c-ares-sys = { version = "5.4.0", path = "c-ares-sys" }
 c-types = "2.0.2"
 itertools = "0.10"
+once_cell = "1.9.0"
 
 [target.'cfg(unix)'.dev-dependencies]
 nix = { version = "0.26", default-features = false, features = ["event"] }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -29,10 +29,11 @@ use crate::utils::{
     ipv4_as_in_addr, ipv6_as_in6_addr, socket_addrv4_as_sockaddr_in, socket_addrv6_as_sockaddr_in6,
 };
 use crate::Flags;
+use once_cell::sync::Lazy;
 use std::sync::Mutex;
 
 // ares_library_init is not thread-safe, so we put a lock around it.
-static ARES_LIBRARY_LOCK: Mutex<()> = Mutex::new(());
+static ARES_LIBRARY_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
 type SocketStateCallback = dyn FnMut(Socket, bool, bool) + Send + 'static;
 


### PR DESCRIPTION
The const fn syntax is a grammatical feature that is only supported after rust stable 1.63. It is recommended to modify the once_cell implemention to support lower versions of rust.