### PR TITLE
remove all PhantomData

### DIFF
--- a/src/caa.rs
+++ b/src/caa.rs
@@ -1,4 +1,3 @@
-use std::marker::PhantomData;
 use std::os::raw::{c_int, c_uchar, c_void};
 use std::{fmt, ptr, slice, str};
 
@@ -12,7 +11,6 @@ use crate::utils::dns_string_as_str;
 #[derive(Debug)]
 pub struct CAAResults {
     caa_reply: *mut c_ares_sys::ares_caa_reply,
-    phantom: PhantomData<c_ares_sys::ares_caa_reply>,
 }
 
 /// The contents of a single CAA record.
@@ -38,10 +36,7 @@ impl CAAResults {
     }
 
     fn new(caa_reply: *mut c_ares_sys::ares_caa_reply) -> Self {
-        CAAResults {
-            caa_reply,
-            phantom: PhantomData,
-        }
+        CAAResults { caa_reply }
     }
 
     /// Returns an iterator over the `CAAResult` values in this `CAAResults`.

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,5 +1,4 @@
 use std::ffi::CString;
-use std::marker::PhantomData;
 use std::mem;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 #[allow(unused_imports)]
@@ -325,7 +324,6 @@ impl Options {
 /// A channel for name service lookups.
 pub struct Channel {
     ares_channel: c_ares_sys::ares_channel,
-    phantom: PhantomData<c_ares_sys::ares_channeldata>,
 
     // For ownership only.
     _socket_state_callback: Option<Arc<SocketStateCallback>>,
@@ -392,7 +390,6 @@ impl Channel {
 
         let channel = Channel {
             ares_channel,
-            phantom: PhantomData,
             _socket_state_callback: options.socket_state_callback,
             #[cfg(cares1_29)]
             _server_state_callback: None,
@@ -432,7 +429,6 @@ impl Channel {
 
         let channel = Channel {
             ares_channel,
-            phantom: PhantomData,
             _socket_state_callback: socket_state_callback,
             #[cfg(cares1_29)]
             _server_state_callback: server_state_callback,

--- a/src/hostent.rs
+++ b/src/hostent.rs
@@ -1,4 +1,3 @@
-use std::marker::PhantomData;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::os::raw::c_char;
 use std::{fmt, ptr, slice};
@@ -56,15 +55,11 @@ pub trait HasHostent<'a>: Sized {
 #[derive(Debug)]
 pub struct HostentOwned {
     inner: *mut c_types::hostent,
-    phantom: PhantomData<c_types::hostent>,
 }
 
 impl HostentOwned {
     pub fn new(hostent: *mut c_types::hostent) -> Self {
-        HostentOwned {
-            inner: hostent,
-            phantom: PhantomData,
-        }
+        HostentOwned { inner: hostent }
     }
 }
 

--- a/src/mx.rs
+++ b/src/mx.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::marker::PhantomData;
 use std::os::raw::{c_int, c_uchar, c_void};
 use std::ptr;
 use std::slice;
@@ -14,7 +13,6 @@ use crate::utils::hostname_as_str;
 #[derive(Debug)]
 pub struct MXResults {
     mx_reply: *mut c_ares_sys::ares_mx_reply,
-    phantom: PhantomData<c_ares_sys::ares_mx_reply>,
 }
 
 /// The contents of a single MX record.
@@ -39,10 +37,7 @@ impl MXResults {
     }
 
     fn new(mx_reply: *mut c_ares_sys::ares_mx_reply) -> Self {
-        MXResults {
-            mx_reply,
-            phantom: PhantomData,
-        }
+        MXResults { mx_reply }
     }
 
     /// Returns an iterator over the `MXResult` values in this `MXResults`.

--- a/src/naptr.rs
+++ b/src/naptr.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::marker::PhantomData;
 use std::os::raw::{c_int, c_uchar, c_void};
 use std::ptr;
 use std::slice;
@@ -14,7 +13,6 @@ use crate::utils::{dns_string_as_str, hostname_as_str};
 #[derive(Debug)]
 pub struct NAPTRResults {
     naptr_reply: *mut c_ares_sys::ares_naptr_reply,
-    phantom: PhantomData<c_ares_sys::ares_naptr_reply>,
 }
 
 /// The contents of a single NAPTR record.
@@ -38,11 +36,8 @@ impl NAPTRResults {
         }
     }
 
-    fn new(reply: *mut c_ares_sys::ares_naptr_reply) -> Self {
-        NAPTRResults {
-            naptr_reply: reply,
-            phantom: PhantomData,
-        }
+    fn new(naptr_reply: *mut c_ares_sys::ares_naptr_reply) -> Self {
+        NAPTRResults { naptr_reply }
     }
 
     /// Returns an iterator over the `NAPTRResult` values in this `NAPTRResults`.

--- a/src/soa.rs
+++ b/src/soa.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::marker::PhantomData;
 use std::os::raw::{c_int, c_uchar, c_void};
 use std::ptr;
 use std::slice;
@@ -12,7 +11,6 @@ use crate::utils::hostname_as_str;
 #[derive(Debug)]
 pub struct SOAResult {
     soa_reply: *mut c_ares_sys::ares_soa_reply,
-    phantom: PhantomData<c_ares_sys::ares_soa_reply>,
 }
 
 impl SOAResult {
@@ -31,10 +29,7 @@ impl SOAResult {
     }
 
     fn new(soa_reply: *mut c_ares_sys::ares_soa_reply) -> Self {
-        SOAResult {
-            soa_reply,
-            phantom: PhantomData,
-        }
+        SOAResult { soa_reply }
     }
 
     /// Returns the name server from this `SOAResult`.

--- a/src/srv.rs
+++ b/src/srv.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::marker::PhantomData;
 use std::os::raw::{c_int, c_uchar, c_void};
 use std::ptr;
 use std::slice;
@@ -14,7 +13,6 @@ use crate::utils::hostname_as_str;
 #[derive(Debug)]
 pub struct SRVResults {
     srv_reply: *mut c_ares_sys::ares_srv_reply,
-    phantom: PhantomData<c_ares_sys::ares_srv_reply>,
 }
 
 /// The contents of a single SRV record.
@@ -40,10 +38,7 @@ impl SRVResults {
     }
 
     fn new(srv_reply: *mut c_ares_sys::ares_srv_reply) -> Self {
-        SRVResults {
-            srv_reply,
-            phantom: PhantomData,
-        }
+        SRVResults { srv_reply }
     }
 
     /// Returns an iterator over the `SRVResult` values in this `SRVResults`.

--- a/src/txt.rs
+++ b/src/txt.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::marker::PhantomData;
 use std::os::raw::{c_int, c_uchar, c_void};
 use std::ptr;
 use std::slice;
@@ -14,7 +13,6 @@ use crate::panic;
 #[derive(Debug)]
 pub struct TXTResults {
     txt_reply: *mut c_ares_sys::ares_txt_ext,
-    phantom: PhantomData<c_ares_sys::ares_txt_ext>,
 }
 
 /// The contents of a single TXT record.
@@ -39,10 +37,7 @@ impl TXTResults {
     }
 
     fn new(txt_reply: *mut c_ares_sys::ares_txt_ext) -> Self {
-        TXTResults {
-            txt_reply,
-            phantom: PhantomData,
-        }
+        TXTResults { txt_reply }
     }
 
     /// Returns an iterator over the `TXTResult` values in this `TXTResults`.

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::marker::PhantomData;
 use std::os::raw::{c_int, c_uchar, c_void};
 use std::ptr;
 use std::slice;
@@ -14,7 +13,6 @@ use crate::utils::dns_string_as_str;
 #[derive(Debug)]
 pub struct URIResults {
     uri_reply: *mut c_ares_sys::ares_uri_reply,
-    phantom: PhantomData<c_ares_sys::ares_uri_reply>,
 }
 
 /// The contents of a single URI record.
@@ -40,10 +38,7 @@ impl URIResults {
     }
 
     fn new(uri_reply: *mut c_ares_sys::ares_uri_reply) -> Self {
-        URIResults {
-            uri_reply,
-            phantom: PhantomData,
-        }
+        URIResults { uri_reply }
     }
 
     /// Returns an iterator over the `URIResult` values in this `URIResults`.


### PR DESCRIPTION
study of the nomicon finds no reason for these

the rules have changed over the years, I am not sure whether they were ever useful or have been redundant since forever