### PR TITLE
Require &mut self for Channel::queue_wait_empty

### DIFF
--- a/c-ares/CHANGELOG.md
+++ b/c-ares/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- `Channel::queue_wait_empty()` now takes `&mut self` (was `&self`): the
+  underlying `ares_queue_wait_empty()` takes a non-`const` channel pointer, so
+  `&self` was unsound given `Channel: Sync`
 - A panic in a user-supplied callback now aborts the process (after the
   default panic hook reports it), rather than being propagated back across the
   c-ares FFI boundary.  Unwinding across `extern "C"` is not permitted, so a

--- a/c-ares/src/channel/mod.rs
+++ b/c-ares/src/channel/mod.rs
@@ -1091,7 +1091,7 @@ impl Channel {
     ///
     /// Pass `None` to wait indefinitely.
     #[cfg(cares1_27)]
-    pub fn queue_wait_empty(&self, timeout: Option<Duration>) -> Result<()> {
+    pub fn queue_wait_empty(&mut self, timeout: Option<Duration>) -> Result<()> {
         let timeout_ms = match timeout {
             None => -1,
             Some(d) => d.as_millis().try_into().unwrap_or(c_int::MAX),
@@ -1437,7 +1437,7 @@ mod tests {
     #[cfg(cares1_27)]
     #[test]
     fn channel_queue_wait_empty() {
-        let channel = Channel::new().unwrap();
+        let mut channel = Channel::new().unwrap();
         // No pending queries, should return immediately.
         // Returns ENOTIMP if c-ares was not built with threading support.
         let result = channel.queue_wait_empty(Some(Duration::ZERO));
@@ -1447,7 +1447,7 @@ mod tests {
     #[cfg(cares1_27)]
     #[test]
     fn channel_queue_wait_empty_none_timeout() {
-        let channel = Channel::new().unwrap();
+        let mut channel = Channel::new().unwrap();
         // None means "wait indefinitely", but with no pending queries it returns immediately.
         let result = channel.queue_wait_empty(None);
         assert!(result.is_ok() || result == Err(Error::ENOTIMP));


### PR DESCRIPTION
ares_queue_wait_empty() takes a non-const ares_channel_t pointer, unlike the other &self-exposed channel accessors (ares_fds, ares_timeout, ares_dup, ares_get_servers_csv, ares_queue_active_queries all take const pointers).  Exposing it as &self was inconsistent with that and, combined with unsafe impl Sync for Channel, would have allowed two threads to call it concurrently on the same channel.