### PR TITLE
iphlpapi is always needed when build on windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,27 @@ jobs:
           cargo run -p c-ares-resolver --example dnsrec
         name: Run c-ares-resolver examples
 
+  build-cmake:
+    name: Build Cmake
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          submodules: true
+      - name: Install Rust (rustup)
+        run: rustup update --no-self-update
+        shell: bash
+      - name: Build
+        run: |
+          cargo build --workspace --features vendored,build-cmake
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest

--- a/c-ares-sys/build/vendored.rs
+++ b/c-ares-sys/build/vendored.rs
@@ -34,6 +34,9 @@ pub(super) fn build() -> Vec<PathBuf> {
     if cfg!(target_os = "macos") {
         println!("cargo:rustc-link-lib=resolv");
     }
+    if cfg!(windows) {
+        println!("cargo:rustc-link-lib=iphlpapi");
+    }
 
     compile();
 
@@ -179,6 +182,5 @@ fn build_msvc(target: &str) {
 
     // Link to compiled library.
     println!("cargo:rustc-link-search={}/lib", build.display());
-    println!("cargo:rustc-link-lib=iphlpapi");
     println!("cargo:rustc-link-lib=static=libcares");
 }


### PR DESCRIPTION
I need to fix the CI here https://github.com/VEY-OSS/vey/actions/runs/29184084135/job/86626954641?pr=59.

Please also release a new version of c-ares-sys after merged.