### PR TITLE
c-ares-sys: fix cross build for windows target

### DIFF
--- a/c-ares-sys/build/vendored.rs
+++ b/c-ares-sys/build/vendored.rs
@@ -34,7 +34,7 @@ pub(super) fn build() -> Vec<PathBuf> {
     if cfg!(target_os = "macos") {
         println!("cargo:rustc-link-lib=resolv");
     }
-    if cfg!(windows) {
+    if env::var("CARGO_CFG_WINDOWS").is_ok() {
         println!("cargo:rustc-link-lib=iphlpapi");
     }
 


### PR DESCRIPTION
Switch to use [cargo environment variables](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts) to detect windows targets.

This is needed when cross build for x86-64-windows-gnu target on Linux hosts (https://github.com/VEY-OSS/vey/actions/runs/29692738080/job/88208218061?pr=68).